### PR TITLE
docs: add a changeset that will trigger the ci flow for publishing

### DIFF
--- a/.changeset/better-signs-turn.md
+++ b/.changeset/better-signs-turn.md
@@ -1,0 +1,12 @@
+---
+"@hanseltime/pulumi-file-utils": patch
+"@hanseltime/pulumi-linode": patch
+"@hanseltime/pulumi-linux": patch
+"@hanseltime/pulumi-linux-base": patch
+"@hanseltime/pulumi-linux-docker": patch
+"@hanseltime/pulumi-linux-iptables": patch
+"@hanseltime/pulumi-utils": patch
+"@hanseltime/traefik": patch
+---
+
+Forcing patch bump for initial change sets

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -3,7 +3,7 @@ run-name: ${{ github.head_ref }} PR Checks
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master, alpha ]
 
 jobs:
   call-test-workflow:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: jamilomar/autopublish-changesets-action@4f9b15bd1f52a161e29f32ef42b712555d987f83
         with:
           # script to be used to publish the pr (changeset version by default)
-          versionScript: ${{ steps.prerelease.outputs.precommand }} && yarn changeset version && yarn format --fix
+          versionScript: ${{ steps.prerelease.outputs.precommand[1:-1] }} && yarn changeset version && yarn format --fix
           # script to be used to publish the pr 
           publishScript: changeset publish
           # commit message


### PR DESCRIPTION
# Summary

This adds a changeset that will be metabolized for the first real publish